### PR TITLE
Fix stuff (#3)

### DIFF
--- a/style.css
+++ b/style.css
@@ -23,7 +23,7 @@ header {
   margin-bottom: 0.5vh;
 }
 body {
-  margin-top: 2vh;
+  margin: 2vh 0 0 0;
   font-size: 2vh;
   color: var(--main-font-color);
   background-color: var(--main-bg-color);
@@ -31,7 +31,6 @@ body {
 section {
   display: flex;
   border-radius: 3vh;
-  padding: 2vh;
   background-color: var(--main-pale-bg-color);
   justify-content: center;
   align-content: center;
@@ -42,6 +41,7 @@ picture {
   object-fit: cover;
 }
 img {
+  display: block;
   width: 100%;
   height: 100%;
   object-fit: cover;
@@ -155,6 +155,7 @@ audio {
 
 /* Blog post page CSS */
 article {
+  margin: 2vh;
   padding: 1vh;
   width: 60%;
   align-items: center;
@@ -231,8 +232,6 @@ article {
     font-size: 3vh;
   }
   section {
-    border-radius: 3vh;
-    padding: 2vh;
     width: 100%;
     justify-content: flex-start;
   }


### PR DESCRIPTION
- body elements have a margin by default, and that margin was causing extra space on the left of a section, so it's been removed.
- Due to fixing the above, the header became offset, as the padding caused the section's to be greater than the width of the body. This was "fixed" by removing the padding and turning it into a margin of the inner element.
- img elements were not displaying correctly because of what I believe to be an odd interaction between the border-radius, `position: relative` (which removes its children from a normal content flow), and the fact that picture element normally have no height/width. This was fixed by removing the relative positioning and giving the img a block display.
- Some duplicate styles were cleaned up.